### PR TITLE
feat: actions bound to a runtime now return a Promise<void> representing their completion

### DIFF
--- a/src/__tests__/boundActions.spec.ts
+++ b/src/__tests__/boundActions.spec.ts
@@ -37,15 +37,17 @@ describe("Bound actions", () => {
 
     const runtime = createRuntime(context, ["Add", "Multiply"])
 
+    const boundActions = runtime.bindActions({ add, multiply })
+
     const onChange = jest.fn()
     runtime.onContextChange(onChange)
 
     await Promise.all([
-      runtime.run(add(2)),
-      runtime.run(multiply(2)),
-      runtime.run(add(3)),
-      runtime.run(multiply(5)),
-      runtime.run(add(1)),
+      boundActions.add(2).asPromise(),
+      boundActions.multiply(2).asPromise(),
+      boundActions.add(3).asPromise(),
+      boundActions.multiply(5).asPromise(),
+      boundActions.add(1).asPromise(),
     ])
 
     expect(runtime.currentState().data).toBe(36)

--- a/src/svelte/createStore.ts
+++ b/src/svelte/createStore.ts
@@ -7,10 +7,15 @@ import { Runtime, createRuntime } from "../runtime.js"
 export interface ContextValue<
   SM extends { [key: string]: BoundStateFn<any, any, any> },
   AM extends { [key: string]: (...args: Array<any>) => Action<any, any> },
+  PM = {
+    [K in keyof AM]: (...args: Parameters<AM[K]>) => {
+      asPromise: () => Promise<void>
+    }
+  },
 > {
   currentState: ReturnType<SM[keyof SM]>
   context: Context
-  actions: AM
+  actions: PM
   runtime?: Runtime
 }
 


### PR DESCRIPTION
BREAKING CHANGE: This is a type-only change
