### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tdreyno/fizz/security/code-scanning/4](https://github.com/tdreyno/fizz/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/main.yml` at the workflow root (right after `on` is a clean location). Since this workflow only checks out code and runs local npm commands, the minimal and safest fix is:

- `contents: read`

This applies to all jobs in the workflow and does not change expected functionality for checkout/build/test steps. No imports, methods, or dependencies are needed—just YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
