### PR TITLE
Refine Copilot instructions for scoped validation and docs anchors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,15 @@
 - Lint all packages: `npm run lint`
 - Run tests: `npm run test`
 - CI-style tests: `npm run test:ci`
-- Run one package test suite from repo root: `npm run test --workspace @tdreyno/fizz`
+- Run one package test suite from repo root:
+  - `npm run test --workspace @tdreyno/fizz`
+  - `npm run test --workspace @tdreyno/fizz-react`
+- Run a specific spec in a package workspace:
+  - `npm run test --workspace @tdreyno/fizz -- <spec-file-pattern>`
+  - `npm run test --workspace @tdreyno/fizz-react -- <spec-file-pattern>`
+- Prefer workspace-scoped validation while iterating:
+  - lint: `npm run lint --workspace <workspace-name> -- <changed-path-or-glob>`
+  - typecheck: `npm run typecheck --workspace <workspace-name>`
 
 ## Validation Workflow (Required)
 
@@ -58,8 +66,18 @@
   - Prettier: `npm exec -- prettier -- --write <changed-files>`
   - ESLint (from touched package): `npm run lint -- <changed-files-or-folder>`
   - Tests (from touched package): `npm run test` or `npm run test -- <spec-file-pattern>`
+- Sonar workflow commands (from repo root):
+  - `npm run coverage:sonar`
+  - `npm run sonar`
+  - `npm run sonar:quality-gate`
 - For SonarQube scope and fallback rules, and `.github` Prettier exceptions, follow `preferences.md`.
 - Report the exact validation commands run and outcomes in the final response.
+
+## Architecture Anchors
+
+- Use `docs/architecture.md` as the canonical reference for runtime transition semantics (handler returns, effects vs outputs, lifecycle ordering).
+- When working in `packages/fizz-react/**`, align behavior with `docs/react-integration.md`.
+- When working in debugger surfaces (`packages/fizz-chrome-debugger/**`), align behavior with `docs/chrome-debugger.md`.
 
 ## Change Hygiene
 


### PR DESCRIPTION
## Why
Recent instruction updates added useful guidance, but they still left gaps that can cause slower iteration and inconsistent verification workflows in this repo.

## What changed
This PR updates `.github/copilot-instructions.md` to make execution guidance more explicit and easier to follow:

- Adds package-specific test command examples for both `@tdreyno/fizz` and `@tdreyno/fizz-react`, including targeted spec runs.
- Adds workspace-scoped lint and typecheck patterns to encourage package-local validation while iterating.
- Documents the Sonar workflow command sequence from repo root:
  - `npm run coverage:sonar`
  - `npm run sonar`
  - `npm run sonar:quality-gate`
- Adds architecture anchors so contributors can quickly reference canonical docs for runtime semantics and integration work:
  - `docs/architecture.md`
  - `docs/react-integration.md`
  - `docs/chrome-debugger.md`

## Notes for reviewers
This is a docs/instructions-only change (1 file) with no runtime behavior changes.